### PR TITLE
Fix multi-value var bugs and ancestor expander bugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@
 
 // Project settings
 group   = "org.veupathdb.eda"
-version = "2.0.3"
+version = "2.1.0"
 
 plugins {
   `java-library`

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/BinaryValuesStreamer.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/BinaryValuesStreamer.java
@@ -63,6 +63,9 @@ public class BinaryValuesStreamer {
     List<Iterator<Long>> idStreams = filter.getSubFilters().stream()
         .map(Functions.fSwallow(subFilter -> streamFilteredEntityIdIndexes(filter.getFilter(subFilter), study)))
         .collect(Collectors.toList());
+    if (idStreams.size() == 1) {
+      return new StreamDeduper(idStreams.get(0));
+    }
     if (filter.getOperation() == MultiFilter.MultiFilterOperation.UNION) {
       return new StreamUnionMerger(idStreams);
     } else { // operation == MultiFilter.MultiFilterOperation.INTERSECT

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/BinaryValuesStreamer.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/BinaryValuesStreamer.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.veupathdb.service.eda.ss.model.variable.binary.BinaryFilesManager.BYTES_RESERVED_FOR_ID;
+
 public class BinaryValuesStreamer {
   private static final LongValueConverter LONG_VALUE_CONVERTER = new LongValueConverter();
-  // TODO: This should be shared with file dumper or possibly read from meta.json to support having it vary per study.
-  private static final int BYTES_RESERVED_FOR_ID = 40;
 
   private final BinaryFilesManager binaryFilesManager;
 

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/DataFlowTreeReducer.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/DataFlowTreeReducer.java
@@ -53,7 +53,9 @@ public class DataFlowTreeReducer {
 
     // Merge all entity ID index data streams if there are more than one.
     if (allStreams.size() == 1) {
-      return allStreams.get(0);
+      // If there is one stream, returned it but ensure that if an entity ID index appears multiple times, it is only
+      // returned once in the resulting stream to account for multi-value variables.
+      return new StreamDeduper(allStreams.get(0));
     }
     return new StreamIntersectMerger(allStreams);
   }

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/StreamDeduper.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/StreamDeduper.java
@@ -1,0 +1,33 @@
+package org.veupathdb.service.eda.ss.model.reducer;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class StreamDeduper implements Iterator<Long> {
+  private Iterator<Long> stream;
+  private Long previous;
+
+  public StreamDeduper(Iterator<Long> stream) {
+    this.stream = stream;
+    this.previous = null;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return stream.hasNext();
+  }
+
+  @Override
+  public Long next() {
+    if (previous == null) {
+      previous = stream.next();
+      return previous;
+    }
+    Long curr = stream.next();
+    while (previous.equals(curr)) {
+      curr = stream.next();
+    }
+    previous = curr;
+    return curr;
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMerger.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMerger.java
@@ -11,6 +11,7 @@ import java.util.*;
 public class StreamIntersectMerger implements Iterator<Long> {
   private final PeekableIterator[] peekableIdIndexStreams;
   private Long nextOutputIndex;
+  private Long lastOutputIndex;
   private PeekableIterator currentIdIndexStream;
   private boolean hasStarted;
   private RingLinkedList streamRing;
@@ -33,6 +34,7 @@ public class StreamIntersectMerger implements Iterator<Long> {
         .toArray(PeekableIterator[]::new);
     this.streamRing = new RingLinkedList(peekableIdIndexStreams);
     this.currentIdIndexStream = streamRing.cursor.currentStream;
+    this.lastOutputIndex = null;
     hasStarted = false;
   }
 
@@ -72,6 +74,13 @@ public class StreamIntersectMerger implements Iterator<Long> {
     // If there's only a single stream, we can short-circuit the merging logic and just return the next value in stream.
     if (streamRing.size == 1) {
       nextOutputIndex = currentIdIndexStream.hasNext() ? currentIdIndexStream.next() : null;
+
+      // Keep track of the last output index to ensure we do not return the same index twice.
+      while (Objects.equals(nextOutputIndex, lastOutputIndex)) {
+        nextOutputIndex = currentIdIndexStream.hasNext() ? currentIdIndexStream.next() : null;
+      }
+
+      lastOutputIndex = nextOutputIndex;
       return;
     }
 

--- a/src/main/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpander.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpander.java
@@ -21,7 +21,7 @@ public class AncestorExpander implements Iterator<Long> {
   private final Iterator<Long> entityIdIndexStream;
   private VariableValueIdPair<Long> currentDescendant;
   private Long currentEntity;
-  private boolean hasStarted = false;
+  private boolean isInitialized = false;
 
   public AncestorExpander(Path descendantsFilePath,
                           AncestorDeserializer deserializer,
@@ -41,7 +41,9 @@ public class AncestorExpander implements Iterator<Long> {
 
   @Override
   public boolean hasNext() {
-    setCurrentIfNotStarted();
+    if (!isInitialized) {
+      initialize();
+    }
     return this.currentDescendant != null;
   }
 
@@ -50,18 +52,22 @@ public class AncestorExpander implements Iterator<Long> {
    */
   @Override
   public Long next() {
-    setCurrentIfNotStarted();
+    if (!isInitialized) {
+      initialize();
+    }
     long toReturn = currentDescendant.getIdIndex();
     nextMatch();
     return toReturn;
   }
 
-  private void setCurrentIfNotStarted() {
-    if (!hasStarted) {
-      currentEntity = entityIdIndexStream.hasNext() ? entityIdIndexStream.next() : null;
-      nextMatch();
-      hasStarted = true;
-    }
+  /**
+   * Initialization method called by hasNext() and next() to ensure that stream is not eagerly consumed by the
+   * constructor. This is called on the first invocation of either of the aforementioned methods.
+   */
+  private void initialize() {
+    currentEntity = entityIdIndexStream.hasNext() ? entityIdIndexStream.next() : null;
+    nextMatch();
+    isInitialized = true;
   }
 
   /**

--- a/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
@@ -25,6 +25,9 @@ public class BinaryFilesManager {
   public static final String META_KEY_NUM_ANCESTORS = "numAncestors";
   static final String DONE_FILE_NAME = "DONE";
 
+  // 50 for max length of ID + 4 reserved to store the size.
+  public static int BYTES_RESERVED_FOR_ID = 54;
+
   public enum Operation { READ, WRITE };
 
   private static final Logger LOG = LogManager.getLogger(BinaryFilesManager.class);

--- a/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
@@ -26,7 +26,7 @@ public class BinaryFilesManager {
   static final String DONE_FILE_NAME = "DONE";
 
   // 50 for max length of ID + 4 reserved to store the size.
-  public static int BYTES_RESERVED_FOR_ID = 54;
+  public static int BYTES_RESERVED_FOR_ID = 40; // 54
 
   public enum Operation { READ, WRITE };
 

--- a/src/test/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMergerTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMergerTest.java
@@ -118,6 +118,12 @@ public class StreamIntersectMergerTest {
       MatcherAssert.assertThat(result, Matchers.contains(2L, 5L, 9L, 10L));
     }
 
+    @Test
+    public void testDuplicatesSingleStream() {
+      final List<Long> s1 = List.of(1L, 1L, 2L, 3L, 3L, 9L, 10L);
+      Iterable<Long> result = () -> new StreamIntersectMerger(List.of(s1.iterator()));
+      MatcherAssert.assertThat(result, Matchers.contains(1L, 2L, 3L, 9L, 10L));
+    }
   }
 
 

--- a/src/test/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMergerTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/reducer/StreamIntersectMergerTest.java
@@ -2,6 +2,7 @@ package org.veupathdb.service.eda.ss.model.reducer;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -37,9 +38,7 @@ public class StreamIntersectMergerTest {
     @Test
     public void testOneStream() {
       final Iterator<Long> stream1 = new ArrayList<>(oneToOneHundred).iterator();
-      StreamIntersectMerger merger = new StreamIntersectMerger(List.of(stream1));
-      Iterable<Long> iterable = () -> merger;
-      MatcherAssert.assertThat(iterable, Matchers.iterableWithSize(100));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> new StreamIntersectMerger(List.of(stream1)));
     }
 
     @Test
@@ -121,8 +120,7 @@ public class StreamIntersectMergerTest {
     @Test
     public void testDuplicatesSingleStream() {
       final List<Long> s1 = List.of(1L, 1L, 2L, 3L, 3L, 9L, 10L);
-      Iterable<Long> result = () -> new StreamIntersectMerger(List.of(s1.iterator()));
-      MatcherAssert.assertThat(result, Matchers.contains(1L, 2L, 3L, 9L, 10L));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> new StreamIntersectMerger(List.of(s1.iterator())));
     }
   }
 

--- a/src/test/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpanderTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpanderTest.java
@@ -98,11 +98,36 @@ public class AncestorExpanderTest {
     List<Long> entityStream = List.of(
         2L, 3L
     );
-    constructExpander(descendantStream, entityStream).forEachRemaining(System.out::println);
     MatcherAssert.assertThat(() -> constructExpander(descendantStream, entityStream),
         Matchers.contains(3L, 4L, 5L, 6L, 7L));
 
   }
+
+  @Test
+  public void testSecondToLastEntityIncluded() {
+    List<VariableValueIdPair<Long>> descendantStream = List.of(
+        new VariableValueIdPair<>(1L, 1L),
+        new VariableValueIdPair<>(2L, 1L),
+        new VariableValueIdPair<>(3L, 2L),
+        new VariableValueIdPair<>(4L, 2L),
+        new VariableValueIdPair<>(5L, 3L),
+        new VariableValueIdPair<>(6L, 3L),
+        new VariableValueIdPair<>(7L, 3L),
+        new VariableValueIdPair<>(8L, 4L),
+        new VariableValueIdPair<>(9L, 4L),
+        new VariableValueIdPair<>(10L, 4L),
+        new VariableValueIdPair<>(11L, 5L),
+        new VariableValueIdPair<>(12L, 5L)
+    );
+    List<Long> entityStream = List.of(
+        2L, 3L, 4L
+    );
+    constructExpander(descendantStream, entityStream).forEachRemaining(System.out::println);
+    MatcherAssert.assertThat(() -> constructExpander(descendantStream, entityStream),
+        Matchers.contains(3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L));
+
+  }
+
 
   private Iterator<Long> constructExpander(List<VariableValueIdPair<Long>> ancestorStream,
                                            List<Long> entityStream) {

--- a/src/test/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpanderTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ss/model/reducer/ancestor/AncestorExpanderTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class AncestorExpanderTest {
 
   @Test
-  public void test() {
+  public void testFirstAndLastAncestorIncluded() {
     List<VariableValueIdPair<Long>> descendantStream = List.of(
         new VariableValueIdPair<>(1L, 1L),
         new VariableValueIdPair<>(2L, 1L),
@@ -79,6 +79,29 @@ public class AncestorExpanderTest {
   public void testEmptyList() {
     Iterable<Long> expander = () -> constructExpander(Collections.emptyList(), Collections.emptyList());
     MatcherAssert.assertThat(expander, Matchers.emptyIterable());
+  }
+
+  @Test
+  public void testSecondToLastIncluded() {
+    List<VariableValueIdPair<Long>> descendantStream = List.of(
+        new VariableValueIdPair<>(1L, 1L),
+        new VariableValueIdPair<>(2L, 1L),
+        new VariableValueIdPair<>(3L, 2L),
+        new VariableValueIdPair<>(4L, 2L),
+        new VariableValueIdPair<>(5L, 3L),
+        new VariableValueIdPair<>(6L, 3L),
+        new VariableValueIdPair<>(7L, 3L),
+        new VariableValueIdPair<>(8L, 4L),
+        new VariableValueIdPair<>(9L, 4L),
+        new VariableValueIdPair<>(10L, 4L)
+    );
+    List<Long> entityStream = List.of(
+        2L, 3L
+    );
+    constructExpander(descendantStream, entityStream).forEachRemaining(System.out::println);
+    MatcherAssert.assertThat(() -> constructExpander(descendantStream, entityStream),
+        Matchers.contains(3L, 4L, 5L, 6L, 7L));
+
   }
 
   private Iterator<Long> constructExpander(List<VariableValueIdPair<Long>> ancestorStream,


### PR DESCRIPTION
## Overview
Found a couple of bugs in the regression testing of MAL-ED and PROMO studies.
1. AncestorExpander was returning descendants of the last entity of the stream when it was intended to be excluded if the 2nd to last item was included
2. StreamIntersectMerger when passed a single stream of IDs with duplicates was incorrectly including the duplicates. This was causing a bug when filtering on a single stream of multi-value variables.

## Testing
Added a couple of missing test cases.
