### PR TITLE
Place NULLs last when sorting and clean up logs

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
@@ -624,7 +624,7 @@ public class FilteredResultFactory {
     return config.isEmpty() ? "" :
         indent + " order by " + config.stream()
             .map(entry -> entry.getKey() + " " + entry.getDirection())
-            .collect(Collectors.joining(", ")) + " NULLS LAST";
+            .collect(Collectors.joining(", "));
   }
 
   /*

--- a/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
@@ -624,7 +624,7 @@ public class FilteredResultFactory {
     return config.isEmpty() ? "" :
         indent + " order by " + config.stream()
             .map(entry -> entry.getKey() + " " + entry.getDirection())
-            .collect(Collectors.joining(", ")) + " ";
+            .collect(Collectors.joining(", ")) + " NULLS LAST";
   }
 
   /*

--- a/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/db/FilteredResultFactory.java
@@ -624,7 +624,7 @@ public class FilteredResultFactory {
     return config.isEmpty() ? "" :
         indent + " order by " + config.stream()
             .map(entry -> entry.getKey() + " " + entry.getDirection())
-            .collect(Collectors.joining(", "));
+            .collect(Collectors.joining(", ")) + " ";
   }
 
   /*

--- a/src/main/java/org/veupathdb/service/eda/ss/model/db/VariableFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/db/VariableFactory.java
@@ -87,11 +87,9 @@ public class VariableFactory {
         getRsOptionalString(rs, VARIABLE_PARENT_ID_COL_NAME, null),
         getRsOptionalString(rs, DEFINITION_COL_NAME, ""),
         parseJsonArrayOfString(rs, HIDE_FROM_COL_NAME));
-    // Only set binary properties if binaryMetadataProvider is present.
-    Optional<BinaryProperties> binaryProperties = binaryMetadataProvider.flatMap(provider ->
-        provider.getBinaryProperties(entity.getStudyAbbrev(), entity, varProps.id));
     return getRsRequiredBoolean(rs, HAS_VALUES_COL_NAME)
-        ? createValueVarFromResultSet(rs, varProps, binaryProperties.orElse(null))
+        ? createValueVarFromResultSet(rs, varProps, binaryMetadataProvider
+        .flatMap(provider -> provider.getBinaryProperties(entity.getStudyAbbrev(), entity, varProps.id)).orElse(null))
         : new VariablesCategory(varProps);
   }
 

--- a/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
+++ b/src/main/java/org/veupathdb/service/eda/ss/model/variable/binary/BinaryFilesManager.java
@@ -313,7 +313,6 @@ public class BinaryFilesManager {
 
   private Optional<Path> getStudyDirIfExists(String studyAbbrev) {
     Path studyDir = studyFinder.findStudyPath(getStudyDirName(studyAbbrev));
-    LOG.debug("Looking for study dir " + studyDir.toString());
     if (!Files.isDirectory(studyDir)) return Optional.empty();
     return Optional.of(studyDir);
   }


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/EdaSubsettingService/issues/130

## Overview
* Put NULLS last when sorted subsetting
* Clean up logs by only looking for binary metadata for variables with values