### PR TITLE
Remove entity ordering for user dataset entity tree queries

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/subset/model/db/EntityFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/db/EntityFactory.java
@@ -44,7 +44,7 @@ public class EntityFactory {
     Entity rootEntity = new SQLRunner(_dataSource, sql, "Get entity tree").executeQuery(rs -> {
       Entity root = null;
       while (rs.next()) {
-        Entity entity = createEntityFromResultSet(rs);
+        Entity entity = createEntityFromResultSet(rs, _orderEntities);
         String parentId = rs.getString(DB.Tables.EntityTypeGraph.Columns.ENTITY_PARENT_ID_COL_NAME);
         if (parentId == null) {
           if (root != null) throw new RuntimeException("In Study " + studyId +
@@ -104,7 +104,7 @@ public class EntityFactory {
         sqlOrderByClause;
   }
 
-  static Entity createEntityFromResultSet(ResultSet rs) {
+  static Entity createEntityFromResultSet(ResultSet rs, boolean orderEntities) {
     try {
       String name = getRsRequiredString(rs, DB.Tables.EntityTypeGraph.Columns.DISPLAY_NAME_COL_NAME);
       // TODO remove this hack when db has plurals
@@ -113,7 +113,9 @@ public class EntityFactory {
       String studyAbbrev = getRsRequiredString(rs, STDY_ABBRV_COL_NM);
       String descrip = getRsOptionalString(rs, DB.Tables.EntityTypeGraph.Columns.DESCRIP_COL_NAME, "No Entity Description available");
       String abbrev = getRsRequiredString(rs, DB.Tables.EntityTypeGraph.Columns.ENTITY_ABBREV_COL_NAME);
-      long loadOrder = getIntegerFromString(rs, DB.Tables.EntityTypeGraph.Columns.ENTITY_LOAD_ORDER_ID, true);
+      long loadOrder = orderEntities
+          ? getIntegerFromString(rs, DB.Tables.EntityTypeGraph.Columns.ENTITY_LOAD_ORDER_ID, true)
+          : -1L;
       boolean hasCollections = getRsRequiredBoolean(rs, DB.Tables.EntityTypeGraph.Columns.ENTITY_HAS_ATTRIBUTE_COLLECTIONS);
 
       boolean isManyToOneWithParent = getRsOptionalBoolean(rs, DB.Tables.EntityTypeGraph.Columns.ENTITY_IS_MANY_TO_ONE_WITH_PARENT, true);

--- a/src/main/java/org/veupathdb/service/eda/subset/model/db/StudyFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/db/StudyFactory.java
@@ -30,15 +30,18 @@ public class StudyFactory implements StudyProvider {
   private final String _dataSchema;
   private final StudySourceType _sourceType;
   private final VariableFactory _variableFactory;
+  private final boolean _sortEntities;
 
   public StudyFactory(DataSource dataSource,
                       String dataSchema,
                       StudySourceType sourceType,
-                      VariableFactory variableFactory) {
+                      VariableFactory variableFactory,
+                      boolean sortEntities) {
     _dataSource = dataSource;
     _dataSchema = dataSchema;
     _sourceType = sourceType;
     _variableFactory = variableFactory;
+    _sortEntities = sortEntities;
   }
 
   private static String getStudyOverviewSql(String appDbSchema) {
@@ -70,7 +73,7 @@ public class StudyFactory implements StudyProvider {
       .findFirst()
       .orElseThrow(notFound(studyId));
 
-    TreeNode<Entity> entityTree = new EntityFactory(_dataSource, _dataSchema).getStudyEntityTree(studyId);
+    TreeNode<Entity> entityTree = new EntityFactory(_dataSource, _dataSchema, _sortEntities).getStudyEntityTree(studyId);
 
     Map<String, Entity> entityIdMap = entityTree.flatten().stream().collect(Collectors.toMap(Entity::getId, e -> e));
 

--- a/src/main/resources/org/veupathdb/service/eda/subset/stubdb/createDbSchema.sql
+++ b/src/main/resources/org/veupathdb/service/eda/subset/stubdb/createDbSchema.sql
@@ -39,6 +39,11 @@ alter table EntityTypeGraph add unique (display_name, study_stable_id, stable_id
 ALTER TABLE EntityTypeGraph
    ADD FOREIGN KEY (study_stable_id) REFERENCES Study (stable_id);
 
+CREATE TABLE EntityType (
+  entity_type_id integer,
+  isa_type varchar(20)
+);
+
 --------------------------------------------------------------------------------------------------
 -- the following tables are per-study.  Their name is formed using the study ID, in this case ds2324.
 -- Each entity type gets two tables:

--- a/src/main/resources/org/veupathdb/service/eda/subset/stubdb/insertDbData.sql
+++ b/src/main/resources/org/veupathdb/service/eda/subset/stubdb/insertDbData.sql
@@ -22,6 +22,13 @@ insert into entityTypeGraph values ('GEMS_PartObs', 'DS-2324', 'GEMS_Part', 'Prt
 insert into entityTypeGraph values ('GEMS_Sample', 'DS-2324', 'GEMS_PartObs', 'Smpl', 'Sample', 'Samples', 'Sample',5,0,0);
 insert into entityTypeGraph values ('GEMS_Treat', 'DS-2324', 'GEMS_PartObs', 'Trtmnt', 'Treatment', 'Treatments', 'Treatment',6,0,0);
 
+insert into EntityType values (1,'household');
+insert into EntityType values (2,'household-obs');
+insert into EntityType values (3,'participant');
+insert into EntityType values (4,'part-obs');
+insert into EntityType values (5,'sample');
+insert into EntityType values (6,'treatment');
+
 ------------------------------------------------------------
 -- STUDY DATA TABLES
 ------------------------------------------------------------

--- a/src/test/java/org/veupathdb/service/eda/subset/model/db/EntityResultSetUtilsTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/db/EntityResultSetUtilsTest.java
@@ -39,7 +39,7 @@ public class EntityResultSetUtilsTest {
     Mockito.when(_binaryMetadataProvider.getBinaryProperties(Mockito.anyString(), Mockito.any(Entity.class), Mockito.anyString()))
             .thenReturn(Optional.empty());
     Study study = new StudyFactory(StubDb.getDataSource(), StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG,
-        new VariableFactory(StubDb.getDataSource(), StubDb.APP_DB_SCHEMA, _binaryMetadataProvider, studyId -> false)).getStudyById(LoadStudyTest.STUDY_ID);
+        new VariableFactory(StubDb.getDataSource(), StubDb.APP_DB_SCHEMA, _binaryMetadataProvider, studyId -> false), true).getStudyById(LoadStudyTest.STUDY_ID);
     new MockFilters(study);
   }
 

--- a/src/test/java/org/veupathdb/service/eda/subset/model/db/LoadStudyTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/db/LoadStudyTest.java
@@ -50,7 +50,7 @@ public class LoadStudyTest {
   @DisplayName("Test reading of entity table") 
   void testReadEntityTable() {
     
-    String sql = EntityFactory.generateEntityTreeSql(STUDY_ID, StubDb.APP_DB_SCHEMA);
+    String sql = EntityFactory.generateEntityTreeSql(STUDY_ID, StubDb.APP_DB_SCHEMA, true);
 
     // get the alphabetically first entity
     Entity entity = new SQLRunner(datasource, sql).executeQuery(rs -> {
@@ -68,7 +68,7 @@ public class LoadStudyTest {
   @Test
   @DisplayName("Test creating entity tree") 
   void testCreateEntityTree() {
-    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA).getStudyEntityTree(STUDY_ID);
+    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA, true).getStudyEntityTree(STUDY_ID);
     
     List<String> entityIds = entityTree.flatten().stream().map(Entity::getId).collect(Collectors.toList());
 
@@ -82,7 +82,7 @@ public class LoadStudyTest {
   @DisplayName("Test reading of variable table") 
   void testReadVariableTable() {
 
-    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA).getStudyEntityTree(STUDY_ID);
+    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA, true).getStudyEntityTree(STUDY_ID);
     
     Map<String, Entity> entityIdMap = entityTree.flatten().stream().collect(Collectors.toMap(Entity::getId, e -> e));
 
@@ -119,7 +119,7 @@ public class LoadStudyTest {
   @DisplayName("Test reading all participant variables")
   void testReadAllVariables() {
 
-    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA).getStudyEntityTree(STUDY_ID);
+    TreeNode<Entity> entityTree = new EntityFactory(datasource, StubDb.APP_DB_SCHEMA,true).getStudyEntityTree(STUDY_ID);
     
     Map<String, Entity> entityIdMap = entityTree.flatten().stream().collect(Collectors.toMap(Entity::getId, e -> e));
 
@@ -135,7 +135,7 @@ public class LoadStudyTest {
   @DisplayName("Load study test") 
   void testLoadStudy() {
     VariableFactory variableFactory = new VariableFactory(datasource, StubDb.APP_DB_SCHEMA, binaryMetadataProvider, studyId -> false);
-    Study study = new StudyFactory(datasource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, variableFactory).getStudyById(STUDY_ID);
+    Study study = new StudyFactory(datasource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, variableFactory, true).getStudyById(STUDY_ID);
     assertNotNull(study);
   }
 }

--- a/src/test/java/org/veupathdb/service/eda/subset/model/db/LoadStudyTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/db/LoadStudyTest.java
@@ -52,10 +52,12 @@ public class LoadStudyTest {
     
     String sql = EntityFactory.generateEntityTreeSql(STUDY_ID, StubDb.APP_DB_SCHEMA, true);
 
+    System.out.println(sql);
+
     // get the alphabetically first entity
     Entity entity = new SQLRunner(datasource, sql).executeQuery(rs -> {
       rs.next();
-      return EntityFactory.createEntityFromResultSet(rs);
+      return EntityFactory.createEntityFromResultSet(rs, true);
     });
 
     assertEquals("GEMS_House", entity.getId());

--- a/src/test/java/org/veupathdb/service/eda/subset/service/StudiesTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/service/StudiesTest.java
@@ -37,7 +37,7 @@ public class StudiesTest {
     _binaryFilesManager = Mockito.mock(BinaryFilesManager.class);
     Mockito.when(_binaryFilesManager.studyHasFiles(Mockito.anyString())).thenReturn(false);
     _variableFactory = new VariableFactory(_dataSource, StubDb.APP_DB_SCHEMA, new EmptyBinaryMetadataProvider(), studyId -> false);
-    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory).getStudyById("DS-2324");
+    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory, true).getStudyById("DS-2324");
     _filtersForTesting = new MockFilters(study);
   }
 
@@ -45,7 +45,7 @@ public class StudiesTest {
   @Test
   @DisplayName("Test variable distribution - no filters")
   void testVariableDistributionNoFilters() {
-    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory).getStudyById("DS-2324");
+    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory, true).getStudyById("DS-2324");
 
     String entityId = "GEMS_Part";
     Entity entity = study.getEntity(entityId).orElseThrow();
@@ -69,7 +69,7 @@ public class StudiesTest {
   @Test
   @DisplayName("Test variable distribution - with filters")
   void testVariableDistribution() {
-    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory).getStudyById("DS-2324");
+    Study study = new StudyFactory(_dataSource, StubDb.APP_DB_SCHEMA, StubDb.USER_STUDIES_FLAG, _variableFactory, true).getStudyById("DS-2324");
 
     String entityId = "GEMS_Part";
     Entity entity = study.getEntity(entityId).orElseThrow();


### PR DESCRIPTION
## Overview
Make entity tree ordering optional. This allows us to disable it for user datasets, where the necessary column for ordering (EntityTypeGraph.entity_type_id) is not available.

Eventually, there will be a dedicated display_order column.