### PR TITLE
Add unit tests and minor refactoring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@
 
 // Project settings
 group   = "org.veupathdb.eda"
-version = "4.16.9"
+version = "5.0.0"
 
 plugins {
   `java-library`

--- a/src/main/java/org/veupathdb/service/eda/subset/model/reducer/BinaryValuesStreamer.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/reducer/BinaryValuesStreamer.java
@@ -55,7 +55,7 @@ public class BinaryValuesStreamer {
    * @param <T>    Type of value associated with {@link V}
    * @throws IOException if there is a failure to open the binary file.
    */
-  public <V, T extends VariableWithValues<V>> FilteredValueIterator<V, Long> streamFilteredEntityIdIndexes(
+  public <V, T extends VariableWithValues<V>> CloseableIterator<Long> streamFilteredEntityIdIndexes(
       SingleValueFilter<V, T> filter, Study study) throws IOException {
     BinaryConverter<V> serializer = filter.getVariable().getBinaryConverter();
     return new FilteredValueIterator<>(
@@ -94,7 +94,7 @@ public class BinaryValuesStreamer {
     }
   }
 
-  public <V> FilteredValueIterator<byte[], VariableValueIdPair<byte[]>> streamIdValueBinaryPairs(
+  public <V> CloseableIterator<VariableValueIdPair<byte[]>> streamIdValueBinaryPairs(
       Study study,
       VariableWithValues<V> variable,
       TabularReportConfig reportConfig) throws IOException {
@@ -102,7 +102,7 @@ public class BinaryValuesStreamer {
     return streamIdValueBinaryPairs(study, variable, reportConfig, binaryFormatter);
   }
 
-  public <V> FilteredValueIterator<byte[], VariableValueIdPair<String>> streamUnformattedIdValueBinaryPairs(
+  public <V> CloseableIterator<VariableValueIdPair<String>> streamUnformattedIdValueBinaryPairs(
       Study study,
       VariableWithValues<V> variable) throws IOException {
     final TabularReportConfig tabularReportConfig = new TabularReportConfig();

--- a/src/main/java/org/veupathdb/service/eda/subset/model/reducer/ValueStream.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/reducer/ValueStream.java
@@ -1,5 +1,6 @@
 package org.veupathdb.service.eda.subset.model.reducer;
 
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.veupathdb.service.eda.subset.model.reducer.formatter.TabularValueFormatter;
 import org.veupathdb.service.eda.subset.model.variable.VariableValueIdPair;
 
@@ -10,7 +11,7 @@ public class ValueStream<T> implements Iterator<VariableValueIdPair<T>> {
   private final Iterator<VariableValueIdPair<T>> stream;
   private final TabularValueFormatter valueFormatter;
 
-  public ValueStream(Iterator<VariableValueIdPair<T>> stream, TabularValueFormatter valueFormatter) {
+  public ValueStream(CloseableIterator<VariableValueIdPair<T>> stream, TabularValueFormatter valueFormatter) {
     this.stream = stream;
     this.valueFormatter = valueFormatter;
     if (stream.hasNext()) {

--- a/src/test/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactoryTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactoryTest.java
@@ -1,0 +1,191 @@
+package org.veupathdb.service.eda.subset.model.db;
+
+import org.gusdb.fgputil.iterator.CloseableIterator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.veupathdb.service.eda.subset.model.Entity;
+import org.veupathdb.service.eda.subset.model.Study;
+import org.veupathdb.service.eda.subset.model.filter.NumberRangeFilter;
+import org.veupathdb.service.eda.subset.model.filter.SingleValueFilter;
+import org.veupathdb.service.eda.subset.model.reducer.BinaryValuesStreamer;
+import org.veupathdb.service.eda.subset.model.variable.NumberVariable;
+import org.veupathdb.service.eda.subset.model.variable.VariableValueIdPair;
+import org.veupathdb.service.eda.subset.model.variable.VariableWithValues;
+import org.veupathdb.service.eda.subset.testutil.TestDataProvider;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+
+public class FilteredResultFactoryTest {
+
+  private BinaryValuesStreamer valuesStreamer;
+  private DataSource ds;
+
+  @BeforeEach
+  public void before() {
+    this.valuesStreamer = Mockito.mock(BinaryValuesStreamer.class);
+    this.ds = Mockito.mock(DataSource.class);
+  }
+
+  @Test
+  public void singleEntityTest() throws Exception {
+    final String studyId = "StudyID";
+    final String studyAbbrev = "Abbrev";
+
+    final Entity root = TestDataProvider.constructEntity();
+    final VariableWithValues<Long> var = TestDataProvider.constructIntVariable(root);
+    root.addVariable(var);
+
+    final Study study = new TestDataProvider.StudyBuilder(studyId, studyAbbrev)
+        .withRoot(root)
+        .build();
+
+    // Mock a stream of 5 entities with a single variable
+    Mockito.when(valuesStreamer.streamUnfilteredEntityIdIndexes(study, root))
+        .thenReturn(CloseableIterator.of(List.of(1L, 2L, 3L, 4L, 5L).iterator()));
+
+    // Mock the stream's variable values corresponding to entities with ID indexes 1-5
+    Mockito.when(valuesStreamer.streamUnformattedIdValueBinaryPairs(Mockito.eq(study), Mockito.eq(var)))
+        .thenReturn(CloseableIterator.of(List.of(
+            new VariableValueIdPair<>(1L, "100"),
+            new VariableValueIdPair<>(2L, "101"),
+            new VariableValueIdPair<>(3L, "102"),
+            new VariableValueIdPair<>(4L, "103"),
+            new VariableValueIdPair<>(5L, "104")
+        ).iterator()));
+
+    // Mock the stream's human-readable entity IDs' mapping to ID index.
+    Mockito.when(valuesStreamer.streamIdMapAsStrings(root, study)).thenReturn(CloseableIterator.of(List.of(
+        new VariableValueIdPair<>(1L, List.of("entity-1")),
+        new VariableValueIdPair<>(2L, List.of("entity-2")),
+        new VariableValueIdPair<>(3L, List.of("entity-3")),
+        new VariableValueIdPair<>(4L, List.of("entity-4")),
+        new VariableValueIdPair<>(5L, List.of("entity-5"))
+    ).iterator()));
+
+    try (CloseableIterator<Map<String, String>> out = FilteredResultFactory.tabularSubsetIterator(
+        study,
+        root,
+        List.of(var),
+        List.of(),
+        valuesStreamer,
+        true,
+        ds,
+        "fake-schema"
+    )) {
+      Assertions.assertEquals("100", out.next().get(var.getDotNotation()));
+      Assertions.assertEquals("101", out.next().get(var.getDotNotation()));
+      Assertions.assertEquals("102", out.next().get(var.getDotNotation()));
+      Assertions.assertEquals("103", out.next().get(var.getDotNotation()));
+      Assertions.assertEquals("104", out.next().get(var.getDotNotation()));
+    }
+  }
+
+  /**
+   * Test producing a tabular subset with a simple two-entity tree.
+   *
+   * Filter based on a numeric variable on the child-entity and output variable values on the parent-entity.
+   */
+  @Test
+  public void multipleEntityTestFiltered() throws Exception {
+    final String studyId = "StudyID";
+    final String studyAbbrev = "Abbrev";
+
+    final Entity root = TestDataProvider.constructEntity();
+    final Entity child = TestDataProvider.constructEntity();
+
+    final NumberVariable<Long> var1 = TestDataProvider.constructIntVariable(root);
+    final NumberVariable<Long> var2 = TestDataProvider.constructIntVariable(root);
+
+    root.addVariable(var1);
+    child.addVariable(var2);
+
+    final SingleValueFilter<Long, NumberVariable<Long>> wayTooBigFilter =
+        new NumberRangeFilter<>("stub", child, var2, 1000L, 1000000L);
+
+    final Study study = new TestDataProvider.StudyBuilder(studyId, studyAbbrev)
+        .withRoot(root)
+        .addEntity(child, root.getId())
+        .build();
+
+    // Mock a stream of 5 entities with a single variable
+    Mockito.when(valuesStreamer.streamFilteredEntityIdIndexes(wayTooBigFilter, study))
+        .thenReturn(CloseableIterator.of(List.of(11L, 31L, 32L, 41L).iterator()));
+
+    Mockito.when(valuesStreamer.streamUnfilteredEntityIdIndexes(study, root))
+        .thenReturn(CloseableIterator.of(List.of(1L, 2L, 3L, 4L, 5L).iterator()));
+
+    Mockito.when(valuesStreamer.streamAncestorIds(child, study, 1)).thenReturn(CloseableIterator.of(List.of(
+        new VariableValueIdPair<>(11L, 1L),
+        new VariableValueIdPair<>(12L, 1L),
+        new VariableValueIdPair<>(13L, 1L),
+        new VariableValueIdPair<>(21L, 2L),
+        new VariableValueIdPair<>(22L, 2L),
+        new VariableValueIdPair<>(23L, 2L),
+        new VariableValueIdPair<>(31L, 3L),
+        new VariableValueIdPair<>(32L, 3L),
+        new VariableValueIdPair<>(41L, 4L),
+        new VariableValueIdPair<>(51L, 5L),
+        new VariableValueIdPair<>(52L, 5L),
+        new VariableValueIdPair<>(53L, 5L)
+        ).iterator()));
+
+    // Mock the parent stream's variable values corresponding to entities with ID indexes 1-5
+    Mockito.when(valuesStreamer.streamUnformattedIdValueBinaryPairs(Mockito.eq(study), Mockito.eq(var1)))
+        .thenReturn(CloseableIterator.of(List.of(
+            new VariableValueIdPair<>(1L, "100"),
+            new VariableValueIdPair<>(2L, "101"),
+            new VariableValueIdPair<>(3L, "102"),
+            new VariableValueIdPair<>(4L, "103"),
+            new VariableValueIdPair<>(5L, "104")
+        ).iterator()));
+
+    // Mock the parent stream's human-readable entity IDs' mapping to ID index.
+    Mockito.when(valuesStreamer.streamIdMapAsStrings(root, study)).thenReturn(CloseableIterator.of(List.of(
+        new VariableValueIdPair<>(1L, List.of("parent-1")),
+        new VariableValueIdPair<>(2L, List.of("parent-2")),
+        new VariableValueIdPair<>(3L, List.of("parent-3")),
+        new VariableValueIdPair<>(4L, List.of("parent-4")),
+        new VariableValueIdPair<>(5L, List.of("parent-5"))
+    ).iterator()));
+
+    // Mock the child stream's human-readable IDs
+    Mockito.when(valuesStreamer.streamIdMapAsStrings(child, study)).thenReturn(CloseableIterator.of(List.of(
+        new VariableValueIdPair<>(11L, List.of("child-11", "parent-1")),
+        new VariableValueIdPair<>(12L, List.of("child-12", "parent-1")),
+        new VariableValueIdPair<>(13L, List.of("child-13", "parent-1")),
+        new VariableValueIdPair<>(21L, List.of("child-21", "parent-2")),
+        new VariableValueIdPair<>(22L, List.of("child-22", "parent-2")),
+        new VariableValueIdPair<>(23L, List.of("child-23", "parent-2")),
+        new VariableValueIdPair<>(31L, List.of("child-31", "parent-3")),
+        new VariableValueIdPair<>(32L, List.of("child-32", "parent-3")),
+        new VariableValueIdPair<>(33L, List.of("child-33", "parent-3")),
+        new VariableValueIdPair<>(41L, List.of("child-41", "parent-4")),
+        new VariableValueIdPair<>(42L, List.of("child-42", "parent-4")),
+        new VariableValueIdPair<>(43L, List.of("child-43", "parent-4")),
+        new VariableValueIdPair<>(51L, List.of("child-51", "parent-5")),
+        new VariableValueIdPair<>(52L, List.of("child-52", "parent-5")),
+        new VariableValueIdPair<>(53L, List.of("child-53", "parent-5"))
+    ).iterator()));
+
+    try (CloseableIterator<Map<String, String>> out = FilteredResultFactory.tabularSubsetIterator(
+        study,
+        root,
+        List.of(var1),
+        List.of(wayTooBigFilter),
+        valuesStreamer,
+        true,
+        ds,
+        "fake-schema"
+    )) {
+
+      // We filtered away all children of entity "101" and "104", hence their absence from expectation.
+      Assertions.assertEquals("100", out.next().get(var1.getDotNotation()));
+      Assertions.assertEquals("102", out.next().get(var1.getDotNotation()));
+      Assertions.assertEquals("103", out.next().get(var1.getDotNotation()));
+    }
+  }
+}

--- a/src/test/java/org/veupathdb/service/eda/subset/model/reducer/JoinNodePerformanceTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/reducer/JoinNodePerformanceTest.java
@@ -37,7 +37,7 @@ public class JoinNodePerformanceTest {
     files = new ArrayList<>();
     final File studyDir = new File(directory, TestDataProvider.STUDY_ID);
     studyDir.mkdir();
-    final File entityDir = new File(studyDir.getAbsolutePath(), TestDataProvider.ENTITY_ID);
+    final File entityDir = new File(studyDir.getAbsolutePath(), TestDataProvider.getNextEntityId());
     entityDir.mkdir();
     final int numFiles = Integer.parseInt(System.getProperty("numFiles", "10"));
     final int recordCount = Integer.parseInt(System.getProperty("recordCount", "2000000"));

--- a/src/test/java/org/veupathdb/service/eda/subset/model/reducer/formatter/MultiValueFormatterTest.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/model/reducer/formatter/MultiValueFormatterTest.java
@@ -1,5 +1,6 @@
 package org.veupathdb.service.eda.subset.model.reducer.formatter;
 
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.veupathdb.service.eda.subset.model.reducer.ValueStream;
@@ -19,7 +20,7 @@ public class MultiValueFormatterTest {
         new VariableValueIdPair<>(3, "3".getBytes(StandardCharsets.UTF_8))
     );
     MultiValueFormatter formatter = new MultiValueFormatter();
-    ValueStream<byte[]> valueStream = new ValueStream<>(utf8Strings.iterator(), formatter);
+    ValueStream<byte[]> valueStream = new ValueStream<>(CloseableIterator.of(utf8Strings.iterator()), formatter);
     Assertions.assertEquals("[0-first,0-second]", new String(formatter.format(valueStream, 0), StandardCharsets.UTF_8));
     Assertions.assertEquals("[1]", new String(formatter.format(valueStream, 1), StandardCharsets.UTF_8));
     Assertions.assertEquals("[3]", new String(formatter.format(valueStream, 3), StandardCharsets.UTF_8));

--- a/src/test/java/org/veupathdb/service/eda/subset/testutil/TestDataProvider.java
+++ b/src/test/java/org/veupathdb/service/eda/subset/testutil/TestDataProvider.java
@@ -19,15 +19,21 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestDataProvider {
-  public static final String ENTITY_ID = "EUPA_1024";
+  private static final AtomicInteger ID_COUNT = new AtomicInteger(1024);
+  private static final AtomicInteger VAR_COUNT = new AtomicInteger(1111);
+
   public static final String STUDY_ID = "GEMS1A";
-  public static final String VARIABLE_ID = "EUPA_1111";
+
+  public static String getNextEntityId() {
+    return "EUPA_" + ID_COUNT.get();
+  }
 
   public static Entity constructEntity() {
     return new Entity(
-        ENTITY_ID,
+        "EUPA_" + ID_COUNT.getAndIncrement(),
         STUDY_ID,
         "My Study",
         "My Studies",
@@ -40,7 +46,7 @@ public class TestDataProvider {
 
   public static IntegerVariable constructIntVariable(Entity entity) {
     return new IntegerVariable(
-        constructGenericVarProps(entity, VARIABLE_ID),
+        constructGenericVarProps(entity, "EUPA_" + VAR_COUNT.getAndIncrement()),
         constructVarValuesProps(VariableType.INTEGER, false),
         new NumberDistributionConfig<>(0L, 10L, 0L, 10L, 2L, 2L),
         new IntegerVariable.Properties("bleep bloops")
@@ -49,7 +55,7 @@ public class TestDataProvider {
 
   public static DateVariable constructDateVariable(Entity entity) {
     return new DateVariable(
-        constructGenericVarProps(entity, VARIABLE_ID),
+        constructGenericVarProps(entity, "EUPA_" + VAR_COUNT.getAndIncrement()),
         constructVarValuesProps(VariableType.DATE, false),
         new DateDistributionConfig(false, VariableDataShape.CONTINUOUS, null, null, "min", "max", 10, "days", null)
     );


### PR DESCRIPTION
## Overview
* Mostly just adding unit tests to the iterator-based subsetting methods in `FilteredResultFactory`
* Made a backward-incompatible change to generalize BinaryValuesStreamer iterators. It's technically backward-incompatible, but all consumers are not broken.