### PR TITLE
Tentative claude fix of portal C_34 error

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactory.java
@@ -20,10 +20,12 @@ import org.gusdb.fgputil.ListBuilder;
 import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.db.platform.DBPlatform;
 import org.gusdb.fgputil.db.pool.DatabaseInstance;
+import org.gusdb.fgputil.db.runner.QueryFlags;
+import org.gusdb.fgputil.db.runner.QueryFlags.CommitAndClose;
 import org.gusdb.fgputil.db.runner.SQLRunner;
 import org.gusdb.fgputil.db.runner.SingleLongResultSetHandler;
 import org.gusdb.fgputil.db.stream.ResultSetIterator;
-import org.gusdb.fgputil.db.stream.ResultSets;
+import org.gusdb.fgputil.db.stream.ResultSetStream;
 import org.gusdb.fgputil.functional.TreeNode;
 import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.iterator.GroupingIterator;
@@ -463,8 +465,18 @@ public class FilteredResultFactory {
     DatabaseInstance dbInstance, String appDbSchema, TreeNode<Entity> prunedEntityTree, Entity outputEntity,
     VariableWithValues<?> distributionVariable, List<Filter> filters) {
     String sql = generateDistributionSql(dbInstance.getPlatform(), appDbSchema, outputEntity, distributionVariable, filters, prunedEntityTree);
-    return ResultSets.openStream(dbInstance.getDataSource(), sql, "Produce variable distribution", row -> Optional.of(
-      new TwoTuple<>(distributionVariable.getType().convertRowValueToStringValue(row), row.getLong(COUNT_COLUMN_NAME))));
+    // Use fetchSize=0 to disable PostgreSQL server-side cursors for distribution queries.
+    // ConnectionWrapper applies a default fetchSize=200 to all statements, but with autocommit=false
+    // this creates server-side cursors (portals) that are closed when the transaction ends.
+    // Distribution queries return aggregated data (one row per distinct value) so fetching all
+    // rows at once is safe, and avoids the "portal does not exist" error on result sets > 200 rows.
+    return new SQLRunner(dbInstance.getDataSource(), sql, "Produce variable distribution").executeQuery(
+        new QueryFlags()
+            .setCommitAndCloseFlag(CommitAndClose.CALLER_IS_RESPONSIBLE)
+            .setFetchSize(0),
+        new Object[]{}, new Integer[]{},
+        rs -> new ResultSetStream<>(rs, row -> Optional.of(
+            new TwoTuple<>(distributionVariable.getType().convertRowValueToStringValue(row), row.getLong(COUNT_COLUMN_NAME)))));
   }
 
   public static long getVariableCount(

--- a/src/main/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/model/db/FilteredResultFactory.java
@@ -20,8 +20,6 @@ import org.gusdb.fgputil.ListBuilder;
 import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.db.platform.DBPlatform;
 import org.gusdb.fgputil.db.pool.DatabaseInstance;
-import org.gusdb.fgputil.db.runner.QueryFlags;
-import org.gusdb.fgputil.db.runner.QueryFlags.CommitAndClose;
 import org.gusdb.fgputil.db.runner.SQLRunner;
 import org.gusdb.fgputil.db.runner.SingleLongResultSetHandler;
 import org.gusdb.fgputil.db.stream.ResultSetIterator;
@@ -470,13 +468,10 @@ public class FilteredResultFactory {
     // this creates server-side cursors (portals) that are closed when the transaction ends.
     // Distribution queries return aggregated data (one row per distinct value) so fetching all
     // rows at once is safe, and avoids the "portal does not exist" error on result sets > 200 rows.
-    return new SQLRunner(dbInstance.getDataSource(), sql, "Produce variable distribution").executeQuery(
-        new QueryFlags()
-            .setCommitAndCloseFlag(CommitAndClose.CALLER_IS_RESPONSIBLE)
-            .setFetchSize(0),
-        new Object[]{}, new Integer[]{},
-        rs -> new ResultSetStream<>(rs, row -> Optional.of(
-            new TwoTuple<>(distributionVariable.getType().convertRowValueToStringValue(row), row.getLong(COUNT_COLUMN_NAME)))));
+    return new SQLRunner(dbInstance.getDataSource(), sql, "Produce variable distribution")
+        .setNotResponsibleForClosing()
+        .executeQuery(rs -> new ResultSetStream<>(rs, row -> Optional.of(
+            new TwoTuple<>(distributionVariable.getType().convertRowValueToStringValue(row), row.getLong(COUNT_COLUMN_NAME)))), 0);
   }
 
   public static long getVariableCount(


### PR DESCRIPTION
Another update: first proposed changes were using newer a `FgpUtil` version which hasn't yet been rolled out for this repo. The change suggested now is much simpler, but may cause memory issues. Leaving this to @ryanrdoherty and others to take care of.

(To reproduce the bug, go to any `DE` search on beta.plasmodb.org, open up the subsetting cell and browse the variables on the **counts** entities.)

Claude Sonnet 4.6 took **45 minutes** and _one whole context window_ to figure this out!
(Opus review as a comment below)

## Root Cause

In lib-eda-subsetting v7.0.0 (`pg-support` branch), `FilteredResultFactory.produceVariableDistribution()` was changed from accepting a raw `DataSource` to a `DatabaseInstance`. Using `dbInstance.getDataSource()` routes connections through `ConnectionWrapper`, which calls `applyFetchSize(200)` on every `prepareStatement()`. Combined with `QueryExecutor.setAutocommit()` always setting `autocommit=false`, this activates **PostgreSQL JDBC server-side cursors**.

The JDBC driver then declares `DECLARE C_34 CURSOR FOR <query>` and fetches rows in batches of 200. For variables with ≤200 distinct values this is invisible — only one batch is needed. For `SEQUENCE_READ_COUNT_SENSE` in `pfal3D7_GENE_EXPRESSION_RNASEQ_DATA` (which has >200 distinct values), the second batch fetch arrives to find portal "C_34" no longer exists on the server.

This failure mode is explicitly documented in `PreparedStatementExecutor.setAutocommit()`:
> *"cursor is closed during commit, leading to runtime error"*

## What is a Portal?

A **portal** in PostgreSQL is a named server-side cursor — an execution context holding the state of a running query, allowing rows to be fetched incrementally in batches.

When PostgreSQL JDBC uses server-side streaming (`fetchSize > 0`, `autocommit=false`), it:
1. Sends `DECLARE C_34 CURSOR FOR <query>` to create the portal
2. Fetches rows in batches: `FETCH 200 FROM C_34`
3. Continues fetching until exhausted

Portals are **transaction-scoped**. When the transaction commits or rolls back, all non-`WITH HOLD` portals are immediately destroyed. "Portal C_34 does not exist" means the cursor was declared, the first batch fetched successfully, but by the time the next batch was requested, the transaction had ended.

## The Fix

`FilteredResultFactory.produceVariableDistribution()` in `lib-eda-subsetting` — replace `ResultSets.openStream()` with a direct `SQLRunner` call using `QueryFlags.setFetchSize(0)`. This overrides `ConnectionWrapper`'s default of 200, disabling server-side cursors for this query. Distribution queries return aggregated data (one row per distinct value), so loading all rows at once is safe.
